### PR TITLE
Implement Reference Shared Item: Toughness

### DIFF
--- a/sheet/Feat.qml
+++ b/sheet/Feat.qml
@@ -1,0 +1,11 @@
+import QtQuick 2.0
+
+import org.lasath.psychic_bear 1.0
+import "str_utils.js" as StringUtils
+
+BonusSource {
+    conditional: false
+
+    uri: "msrc://feats/" + StringUtils.camelize(name)
+}
+

--- a/sheet/character.qrc
+++ b/sheet/character.qrc
@@ -8,6 +8,8 @@
         <file>SavingThrow.qml</file>
         <file>CarryCapacity.qml</file>
         <file>jarjee/JeanClaude.qml</file>
+        <file>shared/feats/Toughness.qml</file>
+        <file>Feat.qml</file>
         <file>str_utils.js</file>
     </qresource>
 </RCC>

--- a/sheet/fernie/Character.qml
+++ b/sheet/fernie/Character.qml
@@ -3,6 +3,8 @@ import QtQuick 2.3
 import "../"
 import org.lasath.psychic_bear 1.0
 
+import "../shared/feats" as Feats
+
 Item {
     AbilityScore {
         id: strength
@@ -226,10 +228,6 @@ Item {
                 Bonus {
                     name: constitution.temporary.modifier.name
                     amount: constitution.temporary.modifier.value * level.value
-                },
-                Bonus {
-                    source: toughness
-                    amount: Math.max(3, level.value)
                 },
                 Bonus {
                     name: "Level 1 Health Roll (Max)"
@@ -517,11 +515,6 @@ Item {
     }
 
     BonusSource {
-        id: toughness
-        name: "Toughness (Feat)"
-    }
-
-    BonusSource {
         id: pointBlankShot
         uri: "msrc://feats/pointBlankShot"
         name: "Point Blank Shot (Feat)"
@@ -540,4 +533,6 @@ Item {
         name: "Extra Knacks: Force of Will (Feat)"
         conditional: true
     }
+
+    Feats.Toughness {}
 }

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -160,7 +160,7 @@ Bonus* Attribute::qlist_at(QQmlListProperty<Bonus> *p, int idx) {
             : attr->m_static_modifiers.at(idx - split);
 }
 void Attribute::qlist_clear(QQmlListProperty<Bonus> *p) {
-    return reinterpret_cast<QList<Bonus *> *>(p->data)->clear();
     Attribute* atr = qobject_cast<Attribute*>(p->object);
     atr->valueChanged(atr->value());
+    return reinterpret_cast<QList<Bonus *> *>(p->data)->clear();
 }

--- a/src/bonus-source.cpp
+++ b/src/bonus-source.cpp
@@ -1,4 +1,5 @@
 #include "bonus-source.h"
+#include "bonus.h"
 
 BonusSource::BonusSource(QQuickItem *parent)
     : QQuickItem(parent), m_active(true), m_conditional(false)
@@ -34,6 +35,30 @@ bool BonusSource::isConditional() const
 bool BonusSource::isEffectivelyConditional() const
 {
     return m_conditional && m_db.isValid();
+}
+
+QQmlListProperty<Bonus> BonusSource::effects()
+{
+    return {
+        this,
+        &m_effects,
+        [](QQmlListProperty<Bonus> *p, Bonus *v) { // append
+            auto src = qobject_cast<BonusSource*>(p->object);
+            Q_ASSERT (src);
+            v->setSource(src);
+        },
+        [](QQmlListProperty<Bonus> *p) { // count
+            auto src = qobject_cast<BonusSource*>(p->object);
+            return src->m_effects.count();
+        },
+        [](QQmlListProperty<Bonus> *p, int idx) { // at
+            auto src = qobject_cast<BonusSource*>(p->object);
+            return src->m_effects.at(idx);
+        },
+        [](QQmlListProperty<Bonus> *p) { // clear
+            return reinterpret_cast<QList<Bonus *> *>(p->data)->clear();
+        }
+    };
 }
 
 void BonusSource::setName(QString arg)

--- a/src/bonus-source.cpp
+++ b/src/bonus-source.cpp
@@ -1,7 +1,7 @@
 #include "bonus-source.h"
 
-BonusSource::BonusSource(QObject *parent)
-    : QObject(parent), m_active(true), m_conditional(false)
+BonusSource::BonusSource(QQuickItem *parent)
+    : QQuickItem(parent), m_active(true), m_conditional(false)
 {
 
 }

--- a/src/bonus-source.h
+++ b/src/bonus-source.h
@@ -16,6 +16,7 @@ class PB_SHARED_EXPORT BonusSource : public QQuickItem
     Q_PROPERTY(bool active READ isActive WRITE setActive NOTIFY activeChanged)
     Q_PROPERTY(bool conditional READ isEffectivelyConditional
                WRITE setConditional NOTIFY conditionalChanged)
+    Q_PROPERTY(QQmlListProperty<Bonus> effects READ effects NOTIFY effectsChanged)
 
 public:
     using List = QList<BonusSource*>;
@@ -28,12 +29,14 @@ public:
     bool isActive() const;
     bool isConditional() const;
     bool isEffectivelyConditional() const;
+    QQmlListProperty<Bonus> effects();
 
 signals:
     void nameChanged(QString arg);
     void uriChanged(QString arg);
     void activeChanged(bool active);
     void conditionalChanged(bool conditional);
+    void effectsChanged(QQmlListProperty<Bonus> effects);
 
 public slots:
     bool fetchDbValues();
@@ -49,6 +52,7 @@ private:
     bool m_active;
     DbHelper m_db;
     bool m_conditional;
+    QList<Bonus*> m_effects;
 };
 
 #endif // BONUSSOURCE_H

--- a/src/bonus-source.h
+++ b/src/bonus-source.h
@@ -4,9 +4,11 @@
 #include "db-helper.h"
 #include "pb-core.h"
 
-#include <QObject>
+#include <QQuickItem>
 
-class PB_SHARED_EXPORT BonusSource : public QObject
+class Bonus;
+
+class PB_SHARED_EXPORT BonusSource : public QQuickItem
 {
     Q_OBJECT
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
@@ -18,7 +20,7 @@ class PB_SHARED_EXPORT BonusSource : public QObject
 public:
     using List = QList<BonusSource*>;
 
-    explicit BonusSource(QObject *parent = 0);
+    explicit BonusSource(QQuickItem *parent = 0);
     ~BonusSource();
 
     QString name() const;

--- a/src/bonus.cpp
+++ b/src/bonus.cpp
@@ -4,7 +4,7 @@
 #include "attribute.h"
 
 Bonus::Bonus(QObject *parent)
-    : QObject(parent), m_amount(0),
+    : QObject(parent), m_amount(0), m_target(nullptr),
       m_source(nullptr), m_type(BonusType::noneType())
 {
 }

--- a/src/bonus.h
+++ b/src/bonus.h
@@ -48,8 +48,8 @@ public slots:
 private:
     int m_amount;
     QString m_name;
-    Source m_source;
     Attribute* m_target;
+    Source m_source;
     BonusType* m_type;
 };
 


### PR DESCRIPTION
Turns out, there were a few missing blocks and bugs preventing shared items from working properly.

This fixes those, and creates Toughness, which can act as a reference implementation for future; assuming we decide it's good enough.

@jarjee : Opinions?
