### PR TITLE
Re-do Touch/FlatFooted AC using Types

### DIFF
--- a/sheet/ArmourClassHelper.qml
+++ b/sheet/ArmourClassHelper.qml
@@ -1,0 +1,43 @@
+import QtQuick 2.0
+
+import org.lasath.psychic_bear 1.0
+import "."
+
+Item {
+    property string prefix: "attr://combat/armourClass"
+
+    Attribute {
+        id: acTouch
+        name: "Armour Class (Touch)"
+        uri: prefix + "/touch"
+
+    }
+
+    Attribute {
+        id: acFlatFooted
+        name: "Armour Class (Flat-Footed)"
+        uri: prefix + "/flatFooted"
+    }
+
+    AttributeRef {
+        id: acRef
+        targetUri: prefix
+
+        onTargetChanged: {
+            if (!target) {
+                return;
+            }
+
+            // TODO: replace with bonus filter
+            for (var m in target.modifiers) {
+                var mod = target.modifiers[m];
+                if (mod.type !== CommonTypes.acDex) {
+                    acFlatFooted.addModifier(mod);
+                }
+                if (mod.type !== CommonTypes.armour) {
+                    acTouch.addModifier(mod);
+                }
+            }
+        }
+    }
+}

--- a/sheet/CommonTypes.qml
+++ b/sheet/CommonTypes.qml
@@ -1,0 +1,22 @@
+pragma Singleton
+import QtQuick 2.0
+
+import org.lasath.psychic_bear 1.0
+
+Item {
+    property BonusType armour: BonusType {
+        stacking: false
+    }
+
+    property BonusType acDex: BonusType {
+        stacking: false
+    }
+
+    property BonusType sheild: BonusType {
+        stacking: false
+    }
+
+    property BonusType deflection: BonusType {
+        stacking: false
+    }
+}

--- a/sheet/CommonTypes.qml
+++ b/sheet/CommonTypes.qml
@@ -12,7 +12,7 @@ Item {
         stacking: false
     }
 
-    property BonusType sheild: BonusType {
+    property BonusType shield: BonusType {
         stacking: false
     }
 

--- a/sheet/character.qrc
+++ b/sheet/character.qrc
@@ -11,5 +11,7 @@
         <file>shared/feats/Toughness.qml</file>
         <file>Feat.qml</file>
         <file>str_utils.js</file>
+        <file>CommonTypes.qml</file>
+        <file>qmldir</file>
     </qresource>
 </RCC>

--- a/sheet/character.qrc
+++ b/sheet/character.qrc
@@ -13,5 +13,6 @@
         <file>str_utils.js</file>
         <file>CommonTypes.qml</file>
         <file>qmldir</file>
+        <file>ArmourClassHelper.qml</file>
     </qresource>
 </RCC>

--- a/sheet/fernie/Character.qml
+++ b/sheet/fernie/Character.qml
@@ -310,60 +310,52 @@ Item {
                 amount: 10
             },
             Bonus {
-                id: acDexBonus
                 name: "Dexterity"
                 amount: dexterity.temporary.modifier.value
+                type: CommonTypes.acDex
             },
             Bonus {
-                id: acArmourBonus
                 name: "Armour (Studded Leather)"
                 amount: 3
+                type: CommonTypes.armour
             },
             Bonus {
                 name: "Hawk Badge (Deflection)"
                 amount: 1
+                type: CommonTypes.deflection
             },
             Bonus {
                 name: "Chain Shirt"
                 amount: 4
+                type: CommonTypes.armour
             }
-
         ]
 
         Attribute {
+            id: acTouch
             name: "Armour Class (Touch)"
             uri: parent.uri + "/touch"
 
-            modifiers: [
-                Bonus {
-                    name: "Normal Armour Class"
-                    amount: armourClass.value
-                },
-                Bonus {
-                    name: "Touch Penalty"
-                    amount: -acArmourBonus.amount
-                }
-            ]
         }
 
         Attribute {
+            id: acFlatFooted
             name: "Armour Class (Flat-Footed)"
             uri: parent.uri + "/flatFooted"
+        }
 
-            modifiers: [
-                Bonus {
-                    name: "Normal Armour Class"
-                    amount: armourClass.value
-                },
-                Bonus {
-                    name: "Flat Footed Penalty"
-                    amount: -acDexBonus.amount
-                },
-                Bonus {
-                    name: "Chain Shirt"
-                    amount: 4
+        // TODO: replace with bonus filter
+        Component.onCompleted: {
+            for (var m in armourClass.modifiers) {
+                var mod = armourClass.modifiers[m];
+                console.assert(mod);
+                if (mod.type !== CommonTypes.acDex) {
+                    acFlatFooted.addModifier(mod);
                 }
-            ]
+                if (mod.type !== CommonTypes.armour) {
+                    acTouch.addModifier(mod);
+                }
+            }
         }
     }
 

--- a/sheet/fernie/Character.qml
+++ b/sheet/fernie/Character.qml
@@ -330,33 +330,9 @@ Item {
                 type: CommonTypes.armour
             }
         ]
+    }
 
-        Attribute {
-            id: acTouch
-            name: "Armour Class (Touch)"
-            uri: parent.uri + "/touch"
-
-        }
-
-        Attribute {
-            id: acFlatFooted
-            name: "Armour Class (Flat-Footed)"
-            uri: parent.uri + "/flatFooted"
-        }
-
-        // TODO: replace with bonus filter
-        Component.onCompleted: {
-            for (var m in armourClass.modifiers) {
-                var mod = armourClass.modifiers[m];
-                console.assert(mod);
-                if (mod.type !== CommonTypes.acDex) {
-                    acFlatFooted.addModifier(mod);
-                }
-                if (mod.type !== CommonTypes.armour) {
-                    acTouch.addModifier(mod);
-                }
-            }
-        }
+    ArmourClassHelper {
     }
 
     Attribute {

--- a/sheet/qmldir
+++ b/sheet/qmldir
@@ -1,0 +1,1 @@
+singleton CommonTypes 1.0 CommonTypes.qml


### PR DESCRIPTION
For the moment, it uses some JavaScript to shuffle the Bonuses across from the AC attribute. In the future, this should be replaced with a property Bonus proxy/filter.
