### PR TITLE
Bugfix: AttributeModule can hide last element

### DIFF
--- a/ui/info/AttributeInfoModule.qml
+++ b/ui/info/AttributeInfoModule.qml
@@ -20,7 +20,14 @@ Module {
         anchors.fill: parent
 
         ListView {
-            anchors.fill: parent
+            id: attributeList
+            anchors {
+                top: parent.top
+                bottom: attributeNewModifier.top
+                left: parent.left
+                right: parent.right
+            }
+
             clip: true
             boundsBehavior: Flickable.StopAtBounds
 
@@ -34,6 +41,7 @@ Module {
         }
 
         Button {
+            id: attributeNewModifier
             anchors {
                 left: parent.left
                 right: parent.right


### PR DESCRIPTION
The "New Static Modifier" button can overlap the list. This fix
adjusts the placement of the list so it will never be under the button.

This means that there is never a concealed element.
